### PR TITLE
Added values for First Person aiming

### DIFF
--- a/recoil.lua
+++ b/recoil.lua
@@ -68,16 +68,27 @@ Citizen.CreateThread(function()
 			_,cAmmo = GetAmmoInClip(PlayerPedId(), wep)
 			if recoils[wep] and recoils[wep] ~= 0 then
 				tv = 0
-				repeat 
-					Wait(0)
-					p = GetGameplayCamRelativePitch()
-					if GetFollowPedCamViewMode() ~= 4 then
+				if GetFollowPedCamViewMode() ~= 4 then
+					repeat 
+						Wait(0)
+						p = GetGameplayCamRelativePitch()
 						SetGameplayCamRelativePitch(p+0.1, 0.2)
-					end
-					tv = tv+0.1
-				until tv >= recoils[wep]
+						tv = tv+0.1
+					until tv >= recoils[wep]
+				else
+					repeat 
+						Wait(0)
+						p = GetGameplayCamRelativePitch()
+						if recoils[wep] > 0.1 then
+							SetGameplayCamRelativePitch(p+0.6, 1.2)
+							tv = tv+0.6
+						else
+							SetGameplayCamRelativePitch(p+0.016, 0.333)
+							tv = tv+0.1
+						end
+					until tv >= recoils[wep]
+				end
 			end
-			
 		end
 	end
 end)


### PR DESCRIPTION
Since the differences between third and first person are completeley F@#!!d up.. i had to make a little if else for values different from 0.1 (pistols) and values > 0.1 (other weapons).. this turns the recoil more or less similiar to the third person (tested with a pistol, carbinerifle, smg, pump shotgun)